### PR TITLE
support for basic authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .settings
 .project
 target
+wait-http-maven-plugin.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Maven plugin that waits until a connection is available. In the case of an http 
 | skip        | false     ||
 | read        | false     | Read the response instead of just opening connection |
 | initialWait | 0         | Time in ms to wait before initial try connecting |
+| username    |           | A username used for basic authentication |
+| password    |           | The password used for basic authentication |
 
 ## Usage
 ```
@@ -39,6 +41,8 @@ Maven plugin that waits until a connection is available. In the case of an http 
             <maxcount>20</maxcount>
             <timeout>10000</timeout>
             <initialWait>10000</initialWait>
+            <username>admin</username>
+            <password>admin</password>
           </configuration>
         </execution>
       </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.kew.maven.plugins</groupId>
 	<artifactId>wait-http-maven-plugin</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>HTTP Wait Plugin. Waits for a URL to return a 200 OK response</name>


### PR DESCRIPTION
2 optional parameters to add support for basic authentication if the target site does not have an unsecure endpoint which you can check.